### PR TITLE
Update BuildProcedureOSX.txt

### DIFF
--- a/Fragmentarium-Source/Build - Mac OS X/BuildProcedureOSX.txt
+++ b/Fragmentarium-Source/Build - Mac OS X/BuildProcedureOSX.txt
@@ -14,18 +14,9 @@ Now check out the source:
 and type the following:
 
     cd Fragmentarium/Fragmentarium-Source/
-    qmake -project -after "CONFIG += opengl"
+    qmake -project -after "QT += widgets opengl"
     qmake -spec macx-xcode Fragmentarium-Source.pro
 
 Now an XCode project file has been created. Open this file in XCode.
-
-Right click on the "Frameworks" and add QtWidgets.framework and QtOpenGL.framework by browsing to their locations at [Qt install location]/[version]/[platform]/lib/ (e.g. ~/Qt/5.3/clang_64/lib).
-The header files now need to be added: click on project and go to the Build tab. Add the following header search paths:
-
-    '[Qt install location]/[version]/[platform]/lib/QtWidgets.framework/Versions/5/Headers'
-    '[Qt install location]/[version]/[platform]/lib/QtOpenGL.framework/Versions/5/Headers'
-
-You may also need to do the same for QtScript.framework and QtXml.framework.
-It might also be necessary to add the SyntopiaCore folder and check the recursive flag.
-It should now be possible to compile and run Fragmentium from XCode.
+It should now be possible to compile and run Fragmentarium from XCode.
 


### PR DESCRIPTION
Using "QT += widgets opengl" with qmake instead of "CONFIG += opengl" eliminates the need to manually tweak the generated xcode project.